### PR TITLE
Dollar sign subscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   "dependencies": {
     "babel-standalone": "^6.24.0",
     "he": "^1.1.1",
-    "marked": "ascent-technologies/marked#a389c3bc"
+    "marked": "/Users/sunkanmi/Documents/ascentregtech/marked"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   "dependencies": {
     "babel-standalone": "^6.24.0",
     "he": "^1.1.1",
-    "marked": "/Users/sunkanmi/Documents/ascentregtech/marked"
+    "marked": "ascent-technologies/marked#21a58f0a"
   }
 }


### PR DESCRIPTION
The text below led to the subscripts bug:

> with less than $2,000,000 in Adjusted Net Capital, $6,000 for each remote location

Because there are two dollar signs in this line, the text between them “2,000,000 in Adjusted Net Capital,” gets marked up as a subscript.

The regex for the subscript match should make sure there is not a space immediately following the first $ and no space immediately preceding the closing $.