### PR TITLE
App 534 dollar sign subscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   "dependencies": {
     "babel-standalone": "^6.24.0",
     "he": "^1.1.1",
-    "marked": "git@github.com:ascent-technologies/marked.git#APP-534-dollar-sign-subscript"
+    "marked": "ascent-technologies/marked#b8e00fd1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   "dependencies": {
     "babel-standalone": "^6.24.0",
     "he": "^1.1.1",
-    "marked": "ascent-technologies/marked#21a58f0a"
+    "marked": "git@github.com:ascent-technologies/marked.git#APP-534-dollar-sign-subscript"
   }
 }


### PR DESCRIPTION
Background: Subscripts are indicated by a $ on either side of the subscript text.

Current: See Paragraph 4. Subscript shows "R." Then click Edit and look at Paragraph 4. You will see that subscript is actually "IRB" ($IRB$) not "R"

Request: Change Subscript to Show "IRB" and ensure that whatever text is between the $ $ is what displays as subscript.

This PR updated `marked` library SHA.